### PR TITLE
MerklePatriciaForestry encoding to newtype

### DIFF
--- a/src/plutarch-onchain-lib/lib/Plutarch/MerkleTree/PatriciaForestry.hs
+++ b/src/plutarch-onchain-lib/lib/Plutarch/MerkleTree/PatriciaForestry.hs
@@ -67,8 +67,7 @@ pblake2b_256_digest_size = pconstant 32
 
 newtype MerklePatriciaForestry = MerklePatriciaForestry BuiltinByteString
   deriving stock (Show, Eq, Ord, Generic)
-PlutusTx.unstableMakeIsData ''MerklePatriciaForestry
-PlutusTx.makeLift ''MerklePatriciaForestry
+  deriving newtype (PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
 
 newtype PMerklePatriciaForestry (s :: S) = PMerklePatriciaForestry (Term s PByteString)
   deriving stock (Generic)


### PR DESCRIPTION
The default derived BuiltinData representation is the less efficient:
```
Constr 0 [B "HASHHERE"]
```

This PR makes it:
```
B "HASH_HERE" 
```