### PR TITLE
Tracks current Plutarch treasury-milestone-2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,19 +15,31 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 index-state:
-  , hackage.haskell.org 2025-04-08T16:51:26Z
-  , cardano-haskell-packages 2025-04-08T16:51:26Z
+  , hackage.haskell.org 2025-08-14T14:31:31Z
+  , cardano-haskell-packages 2025-08-14T14:31:31Z
 
 with-compiler: ghc-9.6.6
+
+constraints:
+  -- These need to be bumped whenever plutarch builds successfully with a higher version number.
+  , plutus-core < 1.52.0.0
+  , plutus-ledger-api < 1.52.0.0
+
+allow-newer:
+  -- These constraints are taken from Plutarch.
+  -- https://github.com/phadej/vec/issues/121
+  ral:QuickCheck,
+  fin:QuickCheck,
+  bin:QuickCheck,
 
 packages:
     src/plutarch-onchain-lib
 
 source-repository-package
     type: git
-    location: https://github.com/Plutonomicon/plutarch-plutus
-    tag: f84a46287b06f36abf8d2d63bec7ff75d32f3e91
-    --sha256: sha256-gKBk9D6DHSEudq7P9+07yXWcgM/QX7NFp0tJXBodopM=
+    location: https://github.com/choener/plutarch-plutus
+    tag: 99315dada86e042bbc1dee5c5ccae158119031eb
+    --sha256: sha256-kgjYtDcqqEsF61QqK5eoxwL4Gbj9A0tAAqw6xH01NB0=
     subdir:
       .
       plutarch-ledger-api

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1745960978,
-        "narHash": "sha256-SKYYwYUYPEuHhVFu+82ExAYkaJ1oZ9MIgRZ2U+MVpe4=",
+        "lastModified": 1757088431,
+        "narHash": "sha256-yUv1JB7WOjoVWhEfk8cKap1P9QDn4hLd4ZHdkNoqvuY=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "b8e34520941dd8631c22c7bf2f1cd68533104fe0",
+        "rev": "8e043cb654d69e62bfb59b80afb2ddda8481f6f7",
         "type": "github"
       },
       "original": {
@@ -279,11 +279,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1746059277,
-        "narHash": "sha256-qZFW7A5SWMvXfsazI7GY+Fi0C4GepSbay7OrGQu2rp0=",
+        "lastModified": 1757469358,
+        "narHash": "sha256-/99VDx6Xf0dN6Fc9YfOSs6iJ+yHB5O+WD3DcCMbpPXM=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "e5dda063af4baccaef266204560ab992ffe996b6",
+        "rev": "7e49da09235b2a09deda5ab6605ccbde130df303",
         "type": "github"
       },
       "original": {

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -11,7 +11,10 @@ let
     inputMap = {
       "https://chap.intersectmbo.org/" = inputs.CHaP;
     };
-    shell.withHoogle = false;
+    shell = {
+      withHoogle = false;
+      tools.haskell-language-server = "2.11.0.0"; # choose one that works with the compiler
+    };
   };
 
   project = lib.iogx.mkHaskellProject {

--- a/src/plutarch-onchain-lib/lib/Plutarch/Core/Crypto.hs
+++ b/src/plutarch-onchain-lib/lib/Plutarch/Core/Crypto.hs
@@ -26,9 +26,9 @@ import Plutarch.Core.Internal.Builtins (pindexBS')
 import Plutarch.Core.PByteString (pdropBS, ptakeBS)
 import Plutarch.Evaluate (unsafeEvalTerm)
 import Plutarch.Internal.Term (Config (NoTracing))
-import Plutarch.Prelude (ClosedTerm, PByteString, PEq ((#==)), PInteger, Term,
-                         pconstant, phexByteStr, phoistAcyclic, pif, plam,
-                         plengthBS, plet, pmod, type (:-->), (#))
+import Plutarch.Prelude (PByteString, PEq ((#==)), PInteger, Term, pconstant,
+                         phexByteStr, phoistAcyclic, pif, plam, plengthBS, plet,
+                         pmod, type (:-->), (#))
 import Plutarch.Script (Script (unScript))
 import PlutusCore.Crypto.Hash qualified as Hash
 import PlutusLedgerApi.Common (serialiseUPLC)
@@ -90,13 +90,13 @@ papplyHashedParameterV3 :: forall s.
 papplyHashedParameterV3 prefix hashedParam =
   pblake2b_224 # (scriptHeader <> postfix)
   where
-    postfix :: ClosedTerm PByteString
+    postfix :: forall t . Term t PByteString
     postfix = phexByteStr "0001"
 
     versionHeader :: Term s PByteString
     versionHeader = unsafeEvalTerm NoTracing (pintegerToByteString # pmostSignificantFirst # 1 # plutusVersion)
 
-    plutusVersion :: ClosedTerm PInteger
+    plutusVersion :: forall t . Term t PInteger
     plutusVersion = pconstant 3
 
     scriptHeader :: Term s PByteString

--- a/src/plutarch-onchain-lib/lib/Plutarch/Core/Eval.hs
+++ b/src/plutarch-onchain-lib/lib/Plutarch/Core/Eval.hs
@@ -36,9 +36,8 @@ import Data.Text.Encoding qualified as Text
 import Data.Text.IO qualified
 import Data.Word (Word8)
 import Plutarch.Evaluate (applyArguments, evalScript, evalScriptHuge)
-import Plutarch.Internal.Term (Config (..), LogLevel (..), TracingMode (..),
-                               compile)
-import Plutarch.Prelude (ClosedTerm)
+import Plutarch.Internal.Term (Config (..), LogLevel (..), S, Term,
+                               TracingMode (..), compile)
 import Plutarch.Pretty (prettyScript)
 import Plutarch.Script (Script, deserialiseScript, serialiseScript)
 import PlutusLedgerApi.V2 (BuiltinByteString, Data, ExBudget)
@@ -49,6 +48,8 @@ import Test.Tasty.HUnit (HasCallStack)
 
 encodeSerialiseCBOR :: Script -> Text
 encodeSerialiseCBOR = Text.decodeUtf8 . Base16.encode . CBOR.serialize' . serialiseScript
+
+type ClosedTerm a = (forall (s' :: S). Term s' a)
 
 evalT :: Config -> ClosedTerm a -> Either Text (Script, ExBudget, [Text])
 evalT cfg x = evalWithArgsT cfg x []

--- a/src/plutarch-onchain-lib/lib/Plutarch/Core/PByteString.hs
+++ b/src/plutarch-onchain-lib/lib/Plutarch/Core/PByteString.hs
@@ -14,17 +14,17 @@ module Plutarch.Core.PByteString (
 ) where
 
 import Plutarch.LedgerApi.Value (PTokenName)
-import Plutarch.Prelude (ClosedTerm, PBool, PByteString, PEq ((#==)), PInteger,
-                         Term, phoistAcyclic, plam, plengthBS, psliceBS, pto,
+import Plutarch.Prelude (PBool, PByteString, PEq ((#==)), PInteger, Term,
+                         phoistAcyclic, plam, plengthBS, psliceBS, pto,
                          type (:-->), (#))
 
 -- | Checks if a tokenName is prefixed by a certain ByteString
-pisPrefixedWith :: ClosedTerm (PTokenName :--> PByteString :--> PBool)
+pisPrefixedWith :: forall s . Term s (PTokenName :--> PByteString :--> PBool)
 pisPrefixedWith = plam $ \tn prefix ->
   pisPrefixOf # prefix # pto tn
 
 -- | Checks if the first ByteString is a prefix of the second
-pisPrefixOf :: ClosedTerm (PByteString :--> PByteString :--> PBool)
+pisPrefixOf :: forall s . Term s (PByteString :--> PByteString :--> PBool)
 pisPrefixOf = plam $ \prefix src ->
   let prefixLength = plengthBS # prefix
       prefix' = psliceBS # 0 # prefixLength # src

--- a/src/plutarch-onchain-lib/lib/Plutarch/Core/Scripts.hs
+++ b/src/plutarch-onchain-lib/lib/Plutarch/Core/Scripts.hs
@@ -8,21 +8,21 @@ module Plutarch.Core.Scripts(
   ) where
 
 import Data.ByteString.Short qualified as SBS
-import Plutarch.Internal.Term (ClosedTerm, Config (..), LogLevel (LogInfo),
-                               Script, TracingMode (DoTracingAndBinds), compile)
+import Plutarch.Internal.Term (Config (..), LogLevel (LogInfo), Script, Term,
+                               TracingMode (DoTracingAndBinds), compile)
 import Plutarch.Internal.Term qualified as P
 import Plutarch.Script qualified as P
 import PlutusLedgerApi.Common qualified as P
 
-tryCompile :: Config -> ClosedTerm a -> Script
+tryCompile :: Config -> (forall s . Term s a ) -> Script
 tryCompile cfg x = case compile cfg x of
   Left e  -> error $ "Compilation failed: " <> show e
   Right s -> s
 
-tryCompileTracingAndBinds :: ClosedTerm a -> Script
+tryCompileTracingAndBinds :: (forall s . Term s a) -> Script
 tryCompileTracingAndBinds = tryCompile (Tracing LogInfo DoTracingAndBinds)
 
-tryCompileNoTracing :: ClosedTerm a -> Script
+tryCompileNoTracing :: (forall s . Term s a) -> Script
 tryCompileNoTracing = tryCompile NoTracing
 
 serialiseScriptShort :: P.Script -> SBS.ShortByteString

--- a/src/plutarch-onchain-lib/lib/Plutarch/Core/ValidationLogic.hs
+++ b/src/plutarch-onchain-lib/lib/Plutarch/Core/ValidationLogic.hs
@@ -20,7 +20,7 @@ import Plutarch.LedgerApi.AssocMap qualified as AssocMap
 import Plutarch.LedgerApi.V3 (AmountGuarantees (..), KeyGuarantees (..),
                               PCredential (..), PRedeemer, PScriptPurpose,
                               PTxInInfo, PTxOut (..), PValue)
-import Plutarch.Prelude (ClosedTerm, PAsData, PBool, PBuiltinList, PBuiltinPair,
+import Plutarch.Prelude (PAsData, PBool, PBuiltinList, PBuiltinPair,
                          PEq ((#==)), PInteger, PList,
                          PListLike (pcons, pelimList, phead, pnil, ptail),
                          PUnit, S, Term, pasConstr, pconstant, perror, pfix,
@@ -106,7 +106,7 @@ pcountInputsFromCred =
 emptyValue :: Value
 emptyValue = mempty
 
-pemptyLedgerValue :: ClosedTerm (PValue 'Sorted 'Positive)
+pemptyLedgerValue :: Term s (PValue 'Sorted 'Positive)
 pemptyLedgerValue = punsafeCoerce $ pconstant @(PValue 'Unsorted 'NoGuarantees) emptyValue
 
 -- | Return the total value spent by all the transaction inputs that are from the provided credential.

--- a/src/plutarch-onchain-lib/test/Plutarch/MerkleTree/Test.hs
+++ b/src/plutarch-onchain-lib/test/Plutarch/MerkleTree/Test.hs
@@ -40,6 +40,8 @@ import Test.Tasty
 import Test.Tasty.QuickCheck (Arbitrary (..), Gen, Property, forAll, vectorOf)
 import Test.Tasty.QuickCheck qualified as QC
 
+type ClosedTerm a = forall s . Term s a
+
 tests :: TestTree
 tests = testGroup "Merkle tree"
   [ testGroup "Merkle Patricia Forestry Tests"

--- a/src/plutarch-onchain-lib/test/TestUtils.hs
+++ b/src/plutarch-onchain-lib/test/TestUtils.hs
@@ -8,7 +8,7 @@ import Test.Tasty.HUnit
 {- | Assert that term compiled and evaluated without errors
 
 -}
-testEval :: TestName -> ClosedTerm a -> TestTree
+testEval :: TestName -> (forall s . Term s a) -> TestTree
 testEval name term = testCase name $ do
   case evalTermResult (Tracing LogDebug DoTracingAndBinds) term of
     FailedToCompile err -> assertFailure $ "Failed to compile: " <> Text.unpack err


### PR DESCRIPTION
* Updates to recent Plutarch changes under `treasury-milestone-2`

* Updates haskell-language-server to work with recent changes. Can easily be split off into its own PR.

* This version uses my backport of Plutarch that is compatible with ghc 9.6. Alternatively, I can provide a version against `treasury-milestone-2` directly. (It most likely just requires changing the tracked commit).